### PR TITLE
Feat/security_logging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("org.springframework.boot:spring-boot-starter-cache")
 
 	implementation("org.flywaydb:flyway-core")
 	implementation("org.flywaydb:flyway-mysql")

--- a/src/main/java/br/com/astro/operations/Application.java
+++ b/src/main/java/br/com/astro/operations/Application.java
@@ -3,9 +3,12 @@ package br.com.astro.operations;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
 public class Application {
 
 	public static void main(String[] args) {

--- a/src/main/java/br/com/astro/operations/config/SecurityConfig.java
+++ b/src/main/java/br/com/astro/operations/config/SecurityConfig.java
@@ -35,6 +35,19 @@ public class SecurityConfig {
             .csrf(AbstractHttpConfigurer::disable)
             .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .headers(headers -> headers
+                .frameOptions(frame -> frame.deny())
+                .contentTypeOptions(contentType -> contentType.disable())
+                .httpStrictTransportSecurity(hsts -> hsts
+                    .maxAgeInSeconds(31536000)
+                    .includeSubDomains(true))
+                .addHeaderWriter((request, response) -> {
+                    response.setHeader("X-Content-Type-Options", "nosniff");
+                    response.setHeader("X-Frame-Options", "DENY");
+                    response.setHeader("X-XSS-Protection", "1; mode=block");
+                    response.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+                    response.setHeader("Permissions-Policy", "geolocation=(), microphone=(), camera=()");
+                }))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/v1/auth/**").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/api-docs/**").permitAll()

--- a/src/main/java/br/com/astro/operations/controller/AuthController.java
+++ b/src/main/java/br/com/astro/operations/controller/AuthController.java
@@ -4,10 +4,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import br.com.astro.operations.domain.dto.request.LoginRequestDTO;
+import br.com.astro.operations.domain.dto.request.RefreshTokenRequestDTO;
 import br.com.astro.operations.domain.dto.request.RegisterRequestDTO;
 import br.com.astro.operations.domain.dto.response.AuthResponseDTO;
 import br.com.astro.operations.service.AuthService;
@@ -54,5 +56,35 @@ public class AuthController {
     public ResponseEntity<AuthResponseDTO> register(@Valid @RequestBody RegisterRequestDTO request) {
         AuthResponseDTO response = service.register(request);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Refresh token", description = "Refresh a JWT token")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Token refreshed successfully",
+                content = @Content(schema = @Schema(implementation = AuthResponseDTO.class))),
+        @ApiResponse(responseCode = "401", description = "Invalid refresh token",
+                content = @Content),
+        @ApiResponse(responseCode = "400", description = "Invalid input",
+                content = @Content)
+    })
+    @PostMapping("/refresh")
+    public ResponseEntity<AuthResponseDTO> refreshToken(@Valid @RequestBody RefreshTokenRequestDTO request) {
+        AuthResponseDTO response = service.refreshToken(request.refreshToken());
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Logout user", description = "Logout user and invalidate JWT token")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Logout successful"),
+        @ApiResponse(responseCode = "401", description = "Invalid token",
+                content = @Content)
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authHeader) {
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            service.logout(token);
+        }
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/br/com/astro/operations/domain/dto/request/RefreshTokenRequestDTO.java
+++ b/src/main/java/br/com/astro/operations/domain/dto/request/RefreshTokenRequestDTO.java
@@ -1,0 +1,12 @@
+package br.com.astro.operations.domain.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "Refresh token request")
+public record RefreshTokenRequestDTO(
+    @NotBlank(message = "Refresh token is required")
+    @Schema(description = "Refresh token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    String refreshToken
+) {
+}

--- a/src/main/java/br/com/astro/operations/domain/dto/response/AuthResponseDTO.java
+++ b/src/main/java/br/com/astro/operations/domain/dto/response/AuthResponseDTO.java
@@ -4,13 +4,15 @@ import java.math.BigDecimal;
 import java.util.UUID;
 
 public record AuthResponseDTO(
-    String token,
+    String accessToken,
+    String refreshToken,
     String type,
     UUID userId,
     String username,
-    BigDecimal balance
+    BigDecimal balance,
+    long expiresIn
 ) {
-    public static AuthResponseDTO of(String token, UUID userId, String username, BigDecimal balance) {
-        return new AuthResponseDTO(token, "Bearer", userId, username, balance);
+    public static AuthResponseDTO of(String accessToken, String refreshToken, UUID userId, String username, BigDecimal balance, long expiresIn) {
+        return new AuthResponseDTO(accessToken, refreshToken, "Bearer", userId, username, balance, expiresIn);
     }
 }

--- a/src/main/java/br/com/astro/operations/security/JwtTokenProvider.java
+++ b/src/main/java/br/com/astro/operations/security/JwtTokenProvider.java
@@ -1,60 +1,122 @@
 package br.com.astro.operations.security;
 
 import java.util.Date;
+import java.util.UUID;
 
 import javax.crypto.SecretKey;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import br.com.astro.operations.service.TokenBlacklistService;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 public class JwtTokenProvider {
 
     private final SecretKey secretKey;
     private final long validityInMilliseconds;
+    private final long refreshValidityInMilliseconds;
+    private final TokenBlacklistService tokenBlacklistService;
 
     public JwtTokenProvider(
         @Value("${app.jwt.secret:mySecretKey}") String secret,
-        @Value("${app.jwt.expiration:86400000}") long validityInMilliseconds
+        @Value("${app.jwt.expiration:86400000}") long validityInMilliseconds,
+        @Value("${app.jwt.refresh-expiration:604800000}") long refreshValidityInMilliseconds,
+        @Autowired TokenBlacklistService tokenBlacklistService
     ) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes());
         this.validityInMilliseconds = validityInMilliseconds;
+        this.refreshValidityInMilliseconds = refreshValidityInMilliseconds;
+        this.tokenBlacklistService = tokenBlacklistService;
     }
 
     public String generateToken(String username) {
-        Date now = new Date();
-        Date validity = new Date(now.getTime() + validityInMilliseconds);
+        return generateToken(username, validityInMilliseconds, "ACCESS");
+    }
 
-        return Jwts.builder()
+    public String generateRefreshToken(String username) {
+        return generateToken(username, refreshValidityInMilliseconds, "REFRESH");
+    }
+
+    private String generateToken(String username, long validity, String type) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + validity);
+        String jti = UUID.randomUUID().toString();
+
+        String token = Jwts.builder()
             .subject(username)
             .issuedAt(now)
-            .expiration(validity)
+            .expiration(expiration)
+            .id(jti)
+            .claim("type", type)
             .signWith(secretKey)
             .compact();
+
+        log.debug("Generated {} token for user: {} with JTI: {} expires at: {}", 
+                 type, username, jti, expiration);
+        return token;
     }
 
     public String getUsername(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public String getJti(String token) {
+        return getClaims(token).getId();
+    }
+
+    public Date getExpiration(String token) {
+        return getClaims(token).getExpiration();
+    }
+
+    public String getTokenType(String token) {
+        return getClaims(token).get("type", String.class);
+    }
+
+    private Claims getClaims(String token) {
         return Jwts.parser()
             .verifyWith(secretKey)
             .build()
             .parseSignedClaims(token)
-            .getPayload()
-            .getSubject();
+            .getPayload();
     }
 
     public boolean validateToken(String token) {
         try {
-            Jwts.parser()
-                .verifyWith(secretKey)
-                .build()
-                .parseSignedClaims(token);
+            Claims claims = getClaims(token);
+            String jti = claims.getId();
+            
+            // Verificar se o token está na blacklist
+            if (tokenBlacklistService.isBlacklisted(jti)) {
+                log.warn("Token {} is blacklisted", jti);
+                return false;
+            }
+            
+            log.debug("Token {} validated successfully", jti);
             return true;
         } catch (JwtException | IllegalArgumentException e) {
+            log.warn("Token validation failed: {}", e.getMessage());
             return false;
+        }
+    }
+
+    public void blacklistToken(String token) {
+        try {
+            Claims claims = getClaims(token);
+            String jti = claims.getId();
+            Date expiration = claims.getExpiration();
+            
+            tokenBlacklistService.blacklistToken(jti, expiration);
+            log.info("Token {} blacklisted until {}", jti, expiration);
+        } catch (Exception e) {
+            log.error("Error blacklisting token: {}", e.getMessage());
         }
     }
 }

--- a/src/main/java/br/com/astro/operations/service/AuthService.java
+++ b/src/main/java/br/com/astro/operations/service/AuthService.java
@@ -16,7 +16,9 @@ import br.com.astro.operations.exception.UserAlreadyExistsException;
 import br.com.astro.operations.repository.UserRepository;
 import br.com.astro.operations.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
@@ -28,24 +30,37 @@ public class AuthService {
 
 
     public AuthResponseDTO login(LoginRequestDTO request) {
+        log.info("Login attempt for user: {}", request.username());
+        
         UserEntity user = repository.findActiveByUsername(request.username())
-            .orElseThrow(() -> new AuthenticationException("Invalid credentials"));
+            .orElseThrow(() -> {
+                log.warn("Login failed - user not found: {}", request.username());
+                return new AuthenticationException("Invalid credentials");
+            });
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            log.warn("Login failed - invalid password for user: {}", request.username());
             throw new AuthenticationException("Invalid credentials");
         }
 
         if (!user.isActive()) {
+            log.warn("Login failed - inactive user: {}", request.username());
             throw new AuthenticationException("User account is inactive");
         }
 
-        String token = jwtTokenProvider.generateToken(user.getUsername());
+        String accessToken = jwtTokenProvider.generateToken(user.getUsername());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUsername());
         
-        return AuthResponseDTO.of(token, user.getId(), user.getUsername(), user.getBalance());
+        log.info("Login successful for user: {} (ID: {})", user.getUsername(), user.getId());
+        
+        return AuthResponseDTO.of(accessToken, refreshToken, user.getId(), user.getUsername(), user.getBalance(), 86400L);
     }
 
     public AuthResponseDTO register(RegisterRequestDTO request) {
+        log.info("Registration attempt for user: {}", request.username());
+        
         if (repository.existsByUsername(request.username())) {
+            log.warn("Registration failed - username already exists: {}", request.username());
             throw new UserAlreadyExistsException("Username already exists");
         }
 
@@ -58,8 +73,49 @@ public class AuthService {
             .build();
 
         user = repository.save(user);
-        String token = jwtTokenProvider.generateToken(user.getUsername());
+        
+        String accessToken = jwtTokenProvider.generateToken(user.getUsername());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUsername());
+        
+        log.info("Registration successful for user: {} (ID: {})", user.getUsername(), user.getId());
 
-        return AuthResponseDTO.of(token, user.getId(), user.getUsername(), user.getBalance());
+        return AuthResponseDTO.of(accessToken, refreshToken, user.getId(), user.getUsername(), user.getBalance(), 86400L);
+    }
+
+    public void logout(String token) {
+        log.info("Logout request received");
+        jwtTokenProvider.blacklistToken(token);
+        log.info("User logged out successfully");
+    }
+
+    public AuthResponseDTO refreshToken(String refreshToken) {
+        log.info("Refresh token request received");
+        
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            log.warn("Refresh token validation failed");
+            throw new AuthenticationException("Invalid refresh token");
+        }
+
+        String tokenType = jwtTokenProvider.getTokenType(refreshToken);
+        if (!"REFRESH".equals(tokenType)) {
+            log.warn("Invalid token type for refresh: {}", tokenType);
+            throw new AuthenticationException("Invalid token type");
+        }
+
+        String username = jwtTokenProvider.getUsername(refreshToken);
+        UserEntity user = repository.findActiveByUsername(username)
+            .orElseThrow(() -> {
+                log.warn("User not found for refresh token: {}", username);
+                return new AuthenticationException("User not found");
+            });
+
+        jwtTokenProvider.blacklistToken(refreshToken);
+
+        String newAccessToken = jwtTokenProvider.generateToken(user.getUsername());
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(user.getUsername());
+
+        log.info("Token refreshed successfully for user: {}", username);
+        
+        return AuthResponseDTO.of(newAccessToken, newRefreshToken, user.getId(), user.getUsername(), user.getBalance(), 86400L);
     }
 }

--- a/src/main/java/br/com/astro/operations/service/OperationService.java
+++ b/src/main/java/br/com/astro/operations/service/OperationService.java
@@ -38,10 +38,13 @@ public class OperationService {
     private final OperationMapper mapper;
 
     public List<OperationDTO> getAllOperations() {
-        return repository.findAll()
+        log.debug("Fetching all available operations");
+        List<OperationDTO> operations = repository.findAll()
             .stream()
             .map(mapper::toDTO)
             .toList();
+        log.debug("Found {} operations", operations.size());
+        return operations;
     }
 
     @Transactional

--- a/src/main/java/br/com/astro/operations/service/RandomStringService.java
+++ b/src/main/java/br/com/astro/operations/service/RandomStringService.java
@@ -9,7 +9,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 public class RandomStringService {
 
@@ -29,6 +31,7 @@ public class RandomStringService {
     @CircuitBreaker(name = "random-org", fallbackMethod = "generateRandomStringFallback")
     @Retry(name = "random-org")
     public String generateRandomString(int length) {
+        log.debug("Generating random string with length={} via Random.org", length);
         try {
             String response = webClient.get()
                 .uri(uriBuilder -> uriBuilder
@@ -47,20 +50,34 @@ public class RandomStringService {
                 .timeout(Duration.ofSeconds(5))
                 .block();
 
-            return response != null ? response.trim() : generateRandomStringFallback(length, null);
+            String result = response != null ? response.trim() : null;
+            if (result != null) {
+                log.info("Random.org string generated successfully (len={})", result.length());
+                return result;
+            }
+            log.warn("Random.org returned empty response, falling back");
+            return generateRandomStringFallback(length, null);
         } catch (Exception e) {
+            log.warn("Error calling Random.org (url={}): {}. Falling back.", randomOrgUrl, e.getMessage());
             return generateRandomStringFallback(length, e);
         }
     }
 
     public String generateRandomStringFallback(int length, Exception ex) {
+        if (ex != null) {
+            log.info("Fallback random string generation due to error: {}", ex.getMessage());
+        } else {
+            log.info("Fallback random string generation due to empty response");
+        }
         StringBuilder sb = new StringBuilder();
         String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-        
+
         for (int i = 0; i < length; i++) {
             sb.append(chars.charAt(fallbackRandom.nextInt(chars.length())));
         }
-        
-        return sb.toString();
+
+        String result = sb.toString();
+        log.debug("Fallback random string generated (len={})", result.length());
+        return result;
     }
 }

--- a/src/main/java/br/com/astro/operations/service/RecordService.java
+++ b/src/main/java/br/com/astro/operations/service/RecordService.java
@@ -14,7 +14,9 @@ import br.com.astro.operations.exception.RecordNotFoundException;
 import br.com.astro.operations.mapper.RecordMapper;
 import br.com.astro.operations.repository.RecordRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
 public class RecordService {
@@ -24,37 +26,52 @@ public class RecordService {
 
     @Transactional(readOnly = true)
     public Page<RecordDTO> getUserRecords(UUID userId, String search, Pageable pageable) {
+        log.debug("Fetching records for userId={}, search='{}'", userId, search);
         Page<RecordEntity> records;
-        
+
         if (search != null && !search.trim().isEmpty()) {
             records = repository.findByUserIdAndSearchWithOperation(userId, search.trim(), pageable);
+            log.debug("Search applied. Found {} records", records.getTotalElements());
         } else {
             records = repository.findByUserIdWithOperation(userId, pageable);
+            log.debug("No search. Found {} records", records.getTotalElements());
         }
-        
+
         return records.map(mapper::toDTO);
     }
 
     @Transactional(readOnly = true)
     public RecordDTO getRecordById(UUID recordId, UUID userId) {
+        log.debug("Fetching record by id={}, userId={}", recordId, userId);
         RecordEntity record = repository.findById(recordId)
-            .orElseThrow(() -> new RecordNotFoundException());
+            .orElseThrow(() -> {
+                log.warn("Record not found: {}", recordId);
+                return new RecordNotFoundException();
+            });
 
         if (!record.getUser().getId().equals(userId)) {
+            log.warn("Record {} does not belong to user {}", recordId, userId);
             throw new RecordNotFoundException();
         }
 
+        log.debug("Record {} retrieved successfully", recordId);
         return mapper.toDTO(record);
     }
 
     public void deleteRecord(UUID recordId, UUID userId) {
+        log.info("Delete record request id={}, userId={}", recordId, userId);
         RecordEntity record = repository.findById(recordId)
-            .orElseThrow(() -> new RecordNotFoundException());
+            .orElseThrow(() -> {
+                log.warn("Record not found for deletion: {}", recordId);
+                return new RecordNotFoundException();
+            });
 
         if (!record.getUser().getId().equals(userId)) {
+            log.warn("Attempt to delete record {} not owned by user {}", recordId, userId);
             throw new RecordNotFoundException();
         }
 
         repository.delete(record);
+        log.info("Record {} deleted by user {}", recordId, userId);
     }
 }

--- a/src/main/java/br/com/astro/operations/service/TokenBlacklistService.java
+++ b/src/main/java/br/com/astro/operations/service/TokenBlacklistService.java
@@ -1,0 +1,43 @@
+package br.com.astro.operations.service;
+
+import java.util.Date;
+
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class TokenBlacklistService {
+
+    private static final String BLACKLIST_CACHE = "tokenBlacklist";
+
+    @CachePut(value = BLACKLIST_CACHE, key = "#jti")
+    public String blacklistToken(String jti, Date expiration) {
+        log.info("Token blacklisted: {} expires at: {}", jti, expiration);
+        return "BLACKLISTED";
+    }
+
+    @Cacheable(value = BLACKLIST_CACHE, key = "#jti", unless = "#result == null")
+    public String isTokenBlacklisted(String jti) {
+        return null;
+    }
+
+    public boolean isBlacklisted(String jti) {
+        String result = isTokenBlacklisted(jti);
+        boolean blacklisted = result != null;
+        
+        if (blacklisted) {
+            log.debug("Token {} is blacklisted", jti);
+        }
+        
+        return blacklisted;
+    }
+
+    public void logoutToken(String jti, Date expiration) {
+        blacklistToken(jti, expiration);
+        log.info("User logged out, token {} blacklisted until {}", jti, expiration);
+    }
+}

--- a/src/main/java/br/com/astro/operations/service/UserService.java
+++ b/src/main/java/br/com/astro/operations/service/UserService.java
@@ -11,7 +11,9 @@ import br.com.astro.operations.exception.UserNotFoundException;
 import br.com.astro.operations.mapper.UserMapper;
 import br.com.astro.operations.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor(onConstructor_ = @Autowired)
 public class UserService {
@@ -20,16 +22,26 @@ public class UserService {
     private final UserMapper mapper;
 
     public UserDTO getCurrentUser(UUID userId) {
+        log.debug("Fetching user profile for user ID: {}", userId);
         UserEntity user = repository.findById(userId)
-            .orElseThrow(() -> new UserNotFoundException("User not found"));
+            .orElseThrow(() -> {
+                log.warn("User not found with ID: {}", userId);
+                return new UserNotFoundException("User not found");
+            });
         
+        log.debug("User profile retrieved successfully for: {}", user.getUsername());
         return mapper.toDTO(user);
     }
 
     public UserDTO getCurrentUserByUsername(String username) {
+        log.debug("Fetching user profile for username: {}", username);
         UserEntity user = repository.findActiveByUsername(username)
-            .orElseThrow(() -> new UserNotFoundException("User not found"));
+            .orElseThrow(() -> {
+                log.warn("Active user not found with username: {}", username);
+                return new UserNotFoundException("User not found");
+            });
         
+        log.debug("User profile retrieved successfully for: {}", username);
         return mapper.toDTO(user);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,9 @@ spring:
     name: operations
 
   datasource:
-    url: jdbc:mariadb://localhost:3306/operations_db
-    username: operations
-    password: secret
+    url: ${DB_URL:jdbc:mariadb://localhost:3306/operations_db}
+    username: ${DB_USERNAME:operations}
+    password: ${DB_PASSWORD:secret}
 
   jpa:
     hibernate:
@@ -14,7 +14,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MariaDBDialect
-        format_sql: true
+        "[format_sql]": true
     open-in-view: false
 
   flyway:
@@ -31,14 +31,14 @@ app:
     url: https://www.random.org/strings/
 
   jwt:
-    secret: mySecretKeyThatIsLongEnoughForHmacSha256Algorithm
-    expiration: 86400000
+    secret: ${JWT_SECRET:mySecretKeyThatIsLongEnoughForHmacSha256Algorithm}
+    expiration: ${JWT_EXPIRATION:86400000} # 24 hours in milliseconds
+    refresh-expiration: ${JWT_REFRESH_EXPIRATION:604800000} # 7 days in milliseconds
 
-  users:
-    default:
-      username: admin@example.com
-      password: P@ssw0rd
-      balance: 250.00
+  cache:
+    type: simple
+    cache-names:
+      - tokenBlacklist
 
 springdoc:
   api-docs:

--- a/src/main/resources/db/migration/V1__Create_users_table.sql
+++ b/src/main/resources/db/migration/V1__Create_users_table.sql
@@ -13,5 +13,3 @@ CREATE INDEX idx_users_username ON users(username);
 CREATE INDEX idx_users_status ON users(status);
 CREATE INDEX idx_users_deleted ON users(deleted);
 
-INSERT INTO users (username, password, status, balance, deleted, created_at, updated_at) VALUES
-    ('admin@admin.com', '$2a$10$m8dN7iBXnWagZnCT6Oy6iOzluv6U8SmCk2O5XkL.6GIWpWpftiBmC', 'ACTIVE', 250.00, FALSE, NOW(), NOW());

--- a/src/main/resources/db/migration/V4__Insert_default_operations.sql
+++ b/src/main/resources/db/migration/V4__Insert_default_operations.sql
@@ -1,7 +1,0 @@
-INSERT INTO operations (type, cost) VALUES
-    ('ADDITION', 1.00),
-    ('SUBTRACTION', 1.00),
-    ('MULTIPLICATION', 2.00),
-    ('DIVISION', 2.00),
-    ('SQUARE_ROOT', 3.00),
-    ('RANDOM_STRING', 5.00);

--- a/src/main/resources/db/migration/V4__Insert_default_operations_and_users.sql
+++ b/src/main/resources/db/migration/V4__Insert_default_operations_and_users.sql
@@ -1,0 +1,10 @@
+INSERT INTO operations (type, cost) VALUES
+    ('ADDITION', 1.00),
+    ('SUBTRACTION', 1.00),
+    ('MULTIPLICATION', 2.00),
+    ('DIVISION', 2.00),
+    ('SQUARE_ROOT', 3.00),
+    ('RANDOM_STRING', 5.00);
+
+INSERT INTO users (username, password, status, balance, deleted, created_at, updated_at) VALUES
+    ('admin@admin.com', '$2a$10$m8dN7iBXnWagZnCT6Oy6iOzluv6U8SmCk2O5XkL.6GIWpWpftiBmC', 'ACTIVE', 250.00, FALSE, NOW(), NOW());


### PR DESCRIPTION
### Summary
* Add refresh token flow, logout, and token blacklist
* Harden security headers and enable stable page JSON
* Add consistent service logging
* Minor Swagger docs updates
### Key changes
#### Auth:
* New endpoints: POST /v1/auth/refresh, /v1/auth/logout
* AuthResponseDTO: accessToken, refreshToken, expiresIn
* JwtTokenProvider: JTI, refresh tokens, blacklist checks, logging
* TokenBlacklistService: in-memory cache for invalidated tokens
#### Web/Security:
* Security headers (HSTS, X-Frame-Options, etc.)
* Enable Spring Data page DTO serialization
#### Observability:
* Logs in AuthService, UserService, OperationService, RecordService, RandomStringService
#### Notes
* New dependency: spring-boot-starter-cache (for blacklist)