### PR TITLE
Correct JPQL syntax in RecordRepository search query

### DIFF
--- a/src/main/java/br/com/astro/operations/repository/RecordRepository.java
+++ b/src/main/java/br/com/astro/operations/repository/RecordRepository.java
@@ -27,7 +27,7 @@ public interface RecordRepository extends JpaRepository<RecordEntity, UUID> {
         JOIN FETCH r.operation 
         WHERE r.user.id = :userId 
         AND r.deleted = false 
-        AND (r.operationResponse LIKE %:search% OR r.operation.type LIKE %:search%)
+        AND (r.operationResponse LIKE CONCAT('%', :search, '%') OR CAST(r.operation.type AS string) LIKE CONCAT('%', :search, '%'))
         """)
     Page<RecordEntity> findByUserIdAndSearchWithOperation(
         @Param("userId") UUID userId, 


### PR DESCRIPTION
### Problem
The search query in RecordRepository.findByUserIdAndSearchWithOperation was using incorrect JPQL syntax with %:search% which is not valid. This would cause runtime errors when the search functionality was used.
### Solution
* Fixed the LIKE clause syntax by using CONCAT('%', :search, '%') instead of %:search%
* Added proper casting of the enum r.operation.type to string using CAST(r.operation.type AS string) to enable string matching against the operation type
### Impact
* Fixes potential runtime errors when users search for records
* Enables proper searching by both operation response content and operation type
* Maintains backward compatibility with existing search functionality